### PR TITLE
ajout de traduction pour fr_CA de calendar

### DIFF
--- a/addons/calendar/i18n/fr_CA.po
+++ b/addons/calendar/i18n/fr_CA.po
@@ -525,32 +525,32 @@ msgstr "Durant le jour"
 #: model:ir.ui.menu,name:calendar.menu_calendar_configuration
 msgid "Calendar"
 msgstr "Calendrier"
-
+//
 #. module: calendar
 #: model:ir.actions.act_window,name:calendar.action_calendar_alarm
 #: model:ir.ui.menu,name:calendar.menu_calendar_alarm
 #: model:ir.ui.view,arch_db:calendar.calendar_alarm_view_form
 #: model:ir.ui.view,arch_db:calendar.view_calendar_alarm_tree
 msgid "Calendar Alarm"
-msgstr ""
+msgstr "Alarme Du Calendrier"
 
 #. module: calendar
 #. openerp-web
 #: code:addons/calendar/static/src/xml/base_calendar.xml:43
 #, python-format
 msgid "Calendar Invitation"
-msgstr ""
+msgstr "Invitation Du Calendrier"
 
 #. module: calendar
 #: model:ir.ui.view,arch_db:calendar.view_calendar_event_form
 msgid "Click here to update only this instance and not all recurrences."
-msgstr ""
+msgstr "Cliquez ici pour mettre à jour uniquement l'instance, pas toutes les récurrences."
 
 #. module: calendar
 #: model:ir.actions.act_window,help:calendar.action_calendar_event
 msgid "Click to schedule a new meeting."
-msgstr ""
-
+msgstr "Cliquez pour planifier un nouveau rendez-vous."
+//
 #. module: calendar
 #: model:ir.model.fields,field_description:calendar.field_calendar_event_color_partner_id
 msgid "Color index of creator"


### PR DESCRIPTION
Nous avons légèrement complété la traduction fr_CA de l'addon calendar.