### PR TITLE
Ajout des traductions au fichier fr_CA.po

### DIFF
--- a/addons/rating/i18n/fr_CA.po
+++ b/addons/rating/i18n/fr_CA.po
@@ -52,7 +52,7 @@ msgstr "Client"
 #. module: rating
 #: model:ir.ui.view,arch_db:rating.view_rating_rating_search
 msgid "Day"
-msgstr ""
+msgstr "Jour"
 
 #. module: rating
 #: model:ir.model.fields,field_description:rating.field_rating_mixin_display_name
@@ -83,35 +83,35 @@ msgstr "Grouper par"
 #. module: rating
 #: model:ir.ui.view,arch_db:rating.view_rating_rating_search
 msgid "Happy"
-msgstr ""
+msgstr "Content"
 
 #. module: rating
 #. openerp-web
 #: code:addons/rating/static/src/js/rating_common.js:26
 #, python-format
 msgid "I don't like it"
-msgstr ""
+msgstr "Je n'aime pas ça"
 
 #. module: rating
 #. openerp-web
 #: code:addons/rating/static/src/js/rating_common.js:25
 #, python-format
 msgid "I hate it"
-msgstr ""
+msgstr "Je déteste ça"
 
 #. module: rating
 #. openerp-web
 #: code:addons/rating/static/src/js/rating_common.js:28
 #, python-format
 msgid "I like it"
-msgstr ""
+msgstr "J'aime ça"
 
 #. module: rating
 #. openerp-web
 #: code:addons/rating/static/src/js/rating_common.js:29
 #, python-format
 msgid "I love it"
-msgstr ""
+msgstr "J'adore ça"
 
 #. module: rating
 #: model:ir.model.fields,field_description:rating.field_rating_mixin_id
@@ -134,7 +134,7 @@ msgstr ""
 #: code:addons/rating/static/src/js/rating_common.js:27
 #, python-format
 msgid "It's okay"
-msgstr ""
+msgstr "C'est correct"
 
 #. module: rating
 #: model:ir.model.fields,field_description:rating.field_rating_mixin___last_update


### PR DESCRIPTION
Les lignes 55, 86, 93, 100, 107, 114 et 137 ont été modifiés dans le but d'ajouter des traductions en français Canada au fichier fr_CA.po de addons/rating/i18n.
