### PR TITLE
Translations added for lines 423 428 450 and 468

### DIFF
--- a/addons/payment/i18n/fr_CA.po
+++ b/addons/payment/i18n/fr_CA.po
@@ -87,7 +87,7 @@ msgstr "Actif"
 #. module: payment
 #: model:ir.model.fields,field_description:payment.field_payment_acquirer_fees_active
 msgid "Add Extra Fees"
-msgstr ""
+msgstr "Ajouter Frais Supplémentaires"
 
 #. module: payment
 #: model:ir.model.fields,field_description:payment.field_payment_transaction_partner_address
@@ -420,12 +420,12 @@ msgstr "Nom"
 #. module: payment
 #: model:ir.model.fields,help:payment.field_payment_method_name
 msgid "Name of the payment method"
-msgstr ""
+msgstr "Nom de la méthode de paiement"
 
 #. module: payment
 #: selection:payment.acquirer,auto_confirm:0
 msgid "No automatic confirmation"
-msgstr ""
+msgstr "Aucune Confirmation Automatique"
 
 #. module: payment
 #: model:ir.model.fields,field_description:payment.field_account_config_settings_module_payment_ogone
@@ -447,7 +447,7 @@ msgstr "Partenaire"
 #. module: payment
 #: model:ir.model.fields,field_description:payment.field_payment_transaction_partner_name
 msgid "Partner Name"
-msgstr ""
+msgstr "Nom du Partenaire"
 
 #. module: payment
 #: model:ir.model,name:payment.model_payment_acquirer
@@ -465,7 +465,7 @@ msgstr ""
 #. module: payment
 #: model:ir.model.fields,field_description:payment.field_payment_transaction_payment_method_id
 msgid "Payment Method"
-msgstr ""
+msgstr "Méthode de Paiement"
 
 #. module: payment
 #: model:ir.model.fields,field_description:payment.field_res_partner_payment_method_ids

--- a/addons/payment/i18n/fr_CA.po
+++ b/addons/payment/i18n/fr_CA.po
@@ -87,7 +87,7 @@ msgstr "Actif"
 #. module: payment
 #: model:ir.model.fields,field_description:payment.field_payment_acquirer_fees_active
 msgid "Add Extra Fees"
-msgstr "Ajouter Frais Supplémentaires"
+msgstr ""
 
 #. module: payment
 #: model:ir.model.fields,field_description:payment.field_payment_transaction_partner_address


### PR DESCRIPTION
In the context of our LOG1000 class, we have translated lines 423, 428, 450 and 468 of the fr_CA.po file in the addons/payment/i18n/ directory. The translations were made in french.