### PR TITLE
Added missing translation in addons/membership/i18n/fr_CA.po

### DIFF
--- a/addons/membership/i18n/fr_CA.po
+++ b/addons/membership/i18n/fr_CA.po
@@ -47,22 +47,22 @@ msgstr ""
 #. module: membership
 #: model:ir.ui.view,arch_db:membership.membership_products_form
 msgid "Add a description..."
-msgstr ""
+msgstr "Ajouter une description..."
 
 #. module: membership
 #: model:ir.ui.view,arch_db:membership.view_res_partner_member_filter
 msgid "All Members"
-msgstr ""
+msgstr "Tous les membres"
 
 #. module: membership
 #: model:ir.ui.view,arch_db:membership.view_res_partner_member_filter
 msgid "All non Members"
-msgstr ""
+msgstr "Tous les non-membres"
 
 #. module: membership
 #: model:ir.model.fields,help:membership.field_membership_membership_line_member_price
 msgid "Amount for the membership"
-msgstr ""
+msgstr "Montant pour l'abonnement"
 
 #. module: membership
 #: model:ir.model.fields,field_description:membership.field_report_membership_associate_member_id


### PR DESCRIPTION
We added the Canadian French translation at lines 50, 55, 60 and 65.
This was done as part of our 3rd assignment in our LOG1000 course.

Nous avons ajouté la traduction canadienne française aux lignes 50, 55, 60 et 65.
Cela a été fait dans le cadre du 3e travail pratique du cours de LOG1000.

-- Équipe 03 (Team 03)